### PR TITLE
Feature: live data overwrite

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -40,6 +40,18 @@
               "required": false,
               "pattern": "^([^,]+(?:,[^,]+)*)?$",
               "description": "Enter a list of comma separated presets"
+            },
+            "showRealTimeModeButton": {
+              "title": "Realtime Mode Button",
+              "type": "boolean",
+              "default": false,
+              "description": "If enabled an additional button will be added in homebridge."
+            },
+            "resetRealTimeModeAfterStream": {
+              "title": "Reset Realtime Mode After Stream",
+              "type": "boolean",
+              "default": true,
+              "description": "If enabled realtime mode will be enabled again, after the current session is closed."
             }
           }
         }
@@ -90,6 +102,14 @@
                 {
                   "key": "controllers[].presets",
                   "notitle": true
+                },
+                {
+                  "key": "controllers[].showRealTimeModeButton",
+                  "notitle": true
+                },
+                {
+                  "key": "controllers[].resetRealTimeModeAfterStream",
+                  "notitle": true
                 }
               ]
             }
@@ -97,7 +117,7 @@
         }
       ]
     },
-    
+
     {
       "type": "fieldset",
       "expandable": true,

--- a/src/WledController.ts
+++ b/src/WledController.ts
@@ -5,6 +5,8 @@ export interface WledController{
     name : string;
     address : string;
     presets : string;
+    showRealTimeModeButton : boolean;
+    resetRealTimeModeAfterStream : boolean;
 }
 
 export enum LightCapability {


### PR DESCRIPTION
In this first draft I have added two config options:
- showRealTimeModeButton
    - if enabled adds a button to disable live mode

- resetRealTimeModeAfterStream
    - if enabled (default): the live data will be ignored until the live data stream ends. If a new stream begins live mode will be active again (thats internal wled functionallity, and can be done through `this.wledClient.ignoreLiveData(until_reboot)` 
    - if disabled: live mode will only change through the new button in homekit or if wled is rebooted

It would be also possible to add another button for changing `resetRealTimeModeAfterStream`, but I don't think its that important.

Homekit wise I want to preserve the homekit internal preset switch. The one below the light switch:
![IMAGE 2024-05-15 23:36:03](https://github.com/smhex/homebridge-wled-ws/assets/31982496/dbdbf6b0-83d6-4939-a544-a1917a3991d9)

But I don't really know how. Homekit is moving the additional button right next to the light switch. You can still click on the color picker and the presets exists in there. But I would prefer them right below the light switch :)
![IMAGE 2024-05-15 23:36:57](https://github.com/smhex/homebridge-wled-ws/assets/31982496/037b14ee-8d93-4b07-a409-16dc2b5ddf37)

Any ideas how to work around this?

In general I am open to rename the config options. I think showRealTimeModeButton and resetRealTimeModeAfterStream are rather long. Couldn't really think of a shorter name :(

Info: In the wled documentation live mode and real time mode are used synonymously. 
