### PR TITLE
Backward compatibility

### DIFF
--- a/src/WledWsAccessory.ts
+++ b/src/WledWsAccessory.ts
@@ -692,6 +692,12 @@ export class WledWsPlatformAccessory {
       .setCharacteristic(this.platform.Characteristic.FirmwareRevision, this.wledClient.info.version)
       .setCharacteristic(this.platform.Characteristic.SerialNumber, this.wledClient.info.mac);
 
+    if (!this.wledClient.info.leds.hasOwnProperty('lightCapabilities')) {
+        this.wledClient.info.leds.segmentLightCapabilities = [1];
+        this.wledClient.info.leds.lightCapabilities = 1;
+        this.log.error('Please update controller %s firmware to latest one!', controller.name);
+    }
+
     const lc : LightCapability = <LightCapability>JSON.parse(this.wledClient.info.leds.lightCapabilities);
 
     if (lc === LightCapability.OnOff){


### PR DESCRIPTION
Fix for old WLED versions like 0.13
I have one and can't update it to latest one, so, it will help to prevent fatal error and Homebridge constant restart.