### PR TITLE
fix: Improve reconnection logic

### DIFF
--- a/src/WledWsPlatformAccessory.ts
+++ b/src/WledWsPlatformAccessory.ts
@@ -972,6 +972,18 @@ export class WledWsPlatformAccessory {
     this.connectionEstablished = false;
     const controller = <WledController>this.accessory.context.device;
     this.platform.log.info('Controller %s disconnected', controller.name);
+
+    if (this.reconnectIntervalId !== null) {
+      clearTimeout(this.reconnectIntervalId);
+    }
+
+    if (!this.connectionClosed) {
+      this.reconnectIntervalId = setTimeout(() => {
+        if (!this.connectionEstablished) {
+          this.connect(true);
+        }
+      }, this.reconnectIntervalMillis);
+    }
   }
 
   /**
@@ -991,7 +1003,9 @@ export class WledWsPlatformAccessory {
 
     if (!this.connectionClosed) {
       this.reconnectIntervalId = setTimeout(() => {
-        this.connect(true);
+        if (!this.connectionEstablished) {
+          this.connect(true);
+        }
       }, this.reconnectIntervalMillis);
     }
   }

--- a/src/WledWsPlatformAccessory.ts
+++ b/src/WledWsPlatformAccessory.ts
@@ -433,6 +433,11 @@ export class WledWsPlatformAccessory {
   async connect(isReconnect: boolean): Promise<boolean> {
     this.connectionClosed = false;
 
+    if (this.wledClient) {
+      this.wledClient.removeAllListeners();
+      this.wledClient.disconnect();
+    }
+
     const controller = <WledController>this.accessory.context.device;
     this.platform.log.info(
       `${isReconnect ? 'Reconnecting' : 'Connecting'} to controller %s at address %s`,

--- a/src/WledWsPlatformAccessory.ts
+++ b/src/WledWsPlatformAccessory.ts
@@ -433,11 +433,6 @@ export class WledWsPlatformAccessory {
   async connect(isReconnect: boolean): Promise<boolean> {
     this.connectionClosed = false;
 
-    if (this.wledClient) {
-      this.wledClient.removeAllListeners();
-      this.wledClient.disconnect();
-    }
-
     const controller = <WledController>this.accessory.context.device;
     this.platform.log.info(
       `${isReconnect ? 'Reconnecting' : 'Connecting'} to controller %s at address %s`,


### PR DESCRIPTION
For a longer time I now had issues where I randomly couldn't control my wled device anymore from HomeKit. A homebridge restart solves the issue.
I now noticed that sometimes happens after a `[wled-ws platform] Controller XYZ disconnected` log, there is no more reconnect. I am pretty sure this happens if there was no onError callback, but wled disconnected. 

Thus I added the same reconnect logic also to the `onDisconnect` function. Even if onDisconnect and onError fire after another the clearTimeout of this.reconnectIntervalId should fix double reconnect tries.

---

Additionally I found in the source code of wled-client that they internally also try a reconnect after 1 second of being disconnected. See https://github.com/ShiftLimits/wled-client/blob/82acf82d9380ad7fb29ffc3605545d459bb6f6ac/src/apis/websocket.ts#L83

So we should check `this.connectionEstablished` again before trying to reconnect, as this could have already happened.

---

Not sure if I missed some other auto reconnect or similar thus I added the `removeAllListener` and `disconnect` call in the connect function, better safe then sorry :)