### PR TITLE
Improve reconnection behavior: Add websocket heartbeat ping

### DIFF
--- a/src/WledWsPlatformAccessory.ts
+++ b/src/WledWsPlatformAccessory.ts
@@ -41,7 +41,10 @@ export class WledWsPlatformAccessory {
   private connectionClosed = false;
   private connectionEstablished = false;
   private reconnectIntervalId: Timeout | null = null;
+  private heartbeatIntervalId: Timeout | null = null;
   private reconnectIntervalMillis = 10000;
+  private heartbeatIntervalMillis = 30000;
+  private heartbeatSupported = true;
   private init = false;
 
   /**
@@ -475,7 +478,7 @@ export class WledWsPlatformAccessory {
     this.wledClient = new WLEDClient({
       host: controller.address,
       websocket: {
-        reconnect: true,
+        reconnect: false, // we have our own reconnect logic, turn off WLEDClient reconnect
       },
       immediate: true,
       secure: false,
@@ -490,31 +493,38 @@ export class WledWsPlatformAccessory {
     });
 
     this.wledClient.on('close', () => {
+      this.clearHeartbeat();
       this.onDisconnected();
     });
 
     // update accessory state
     this.wledClient.on('update:state', () => {
+      this.resetHeartbeatInterval();
       this.onStateReceived();
     });
 
     this.wledClient.on('update:presets', () => {
+      this.resetHeartbeatInterval();
       this.onPresetsReceived();
     });
 
     this.wledClient.on('update:effects', () => {
+      this.resetHeartbeatInterval();
       this.onEffectsReceived();
     });
 
     this.wledClient.on('update:config', () => {
+      this.resetHeartbeatInterval();
       this.onConfigReceived();
     });
 
     this.wledClient.on('update:info', () => {
+      this.resetHeartbeatInterval();
       this.onInfoReceived();
     });
 
     this.wledClient.on('error', (error) => {
+      this.clearHeartbeat();
       this.onError(error);
     });
 
@@ -540,8 +550,10 @@ export class WledWsPlatformAccessory {
 
       if (this.reconnectIntervalId !== null) {
         clearTimeout(this.reconnectIntervalId);
+        this.reconnectIntervalId = null;
       }
 
+      this.clearHeartbeat();
       this.connectionClosed = true;
       this.wledClient.disconnect();
     }
@@ -1007,8 +1019,95 @@ export class WledWsPlatformAccessory {
     const controller = <WledController>this.accessory.context.device;
     this.platform.log.info('Controller %s connected', controller.name);
     this.connectionEstablished = true;
+    this.resetHeartbeatInterval();
   }
-
+  
+  /**
+   * Reset the active websocket heartbeat interval. Any websocket data from WLED
+   * counts as activity, so the next ping is only sent after the connection has
+   * been quiet for heartbeatIntervalMillis.
+   */
+  resetHeartbeatInterval() {
+    this.clearHeartbeat();
+    
+    if (
+      !this.heartbeatSupported ||
+      this.connectionClosed ||
+      !this.connectionEstablished
+    ) {
+      return;
+    }
+    
+    this.heartbeatIntervalId = setTimeout(() => {
+      this.sendHeartbeatPing();
+    }, this.heartbeatIntervalMillis);
+  }
+  
+  /**
+   * Send a websocket ping and reconnect if the underlying websocket rejects it.
+   */
+  sendHeartbeatPing() {
+    if (
+      !this.heartbeatSupported ||
+      this.connectionClosed ||
+      !this.connectionEstablished
+    ) {
+      return;
+    }
+    
+    const controller = <WledController>this.accessory.context.device;
+    const websocket = this.wledClient.WSAPI?.websocket;
+    const ping = websocket?.ping;
+    
+    if (typeof ping !== 'function') {
+      this.heartbeatSupported = false;
+      this.clearHeartbeat();
+      
+      this.platform.log.debug(
+        'Controller %s websocket heartbeat disabled; ping() is unavailable.',
+        controller.name,
+      );
+      
+      return;
+    }
+    
+    try {
+      ping.call(websocket);
+      this.resetHeartbeatInterval();
+    } catch (error) {
+      this.platform.log.info(
+        'Controller %s websocket heartbeat ping failed; reconnecting: %s',
+        controller.name,
+        error instanceof Error ? error.message : error,
+      );
+      
+      this.connectionEstablished = false;
+      this.clearHeartbeat();
+      
+      try {
+        this.wledClient.disconnect();
+      } catch (disconnectError) {
+        this.platform.log.error(
+          'Error disconnecting stale websocket for controller %s: %s',
+          controller.name,
+          disconnectError instanceof Error ? disconnectError.message : disconnectError,
+        );
+      }
+      
+      this.onDisconnected();
+    }
+  }
+  
+  /**
+   * Clear the active websocket heartbeat interval.
+   */
+  clearHeartbeat() {
+    if (this.heartbeatIntervalId !== null) {
+      clearTimeout(this.heartbeatIntervalId);
+      this.heartbeatIntervalId = null;
+    }
+  }
+  
   /**
    * Callback: connection to the controller is closed
    */
@@ -1016,9 +1115,12 @@ export class WledWsPlatformAccessory {
     this.connectionEstablished = false;
     const controller = <WledController>this.accessory.context.device;
     this.platform.log.info('Controller %s disconnected', controller.name);
-
+    
+    this.clearHeartbeat();
+    
     if (this.reconnectIntervalId !== null) {
       clearTimeout(this.reconnectIntervalId);
+      this.reconnectIntervalId = null;
     }
 
     if (!this.connectionClosed) {
@@ -1040,9 +1142,12 @@ export class WledWsPlatformAccessory {
       controller.name,
     );
     this.connectionEstablished = false;
-
+    
+    this.clearHeartbeat();
+    
     if (this.reconnectIntervalId !== null) {
       clearTimeout(this.reconnectIntervalId);
+      this.reconnectIntervalId = null;
     }
 
     if (!this.connectionClosed) {


### PR DESCRIPTION
Tested over approximately 72 hours with no loss of connection in an environment where a silent loss of connection was consistently happening during idle periods of around 24hrs.

This PR does 2 things:

1) Sets reconnect to false for WLEDClient - this disables the reconnect behavior inside of WLEDClient so there is never a potential conflict between 2 different reconnection behaviors. This was mentioned as a possibility and guarded against in #425 - this further guards against any potential conflict.

2) Implements a "heartbeat" reconnect timer that sends periodic pings using WebSocket API exposed by WLEDClient when communication is idle. This catches scenarios where the connection is dropped but no close event is triggered (silent disconnects). The heartbeat timer is reset any time a successful communication occurs - no need to ping if we already know the connection is alive.

The ping method is specifically documented at: https://websocket.org/guides/troubleshooting/timeout/ and was not currently implemented here in the plugin or in the client library.

Note: the "heartbeatSupported" property is there to guard against the ping() function not being available. Currently the ping() function is exposed through private API in WLEDClient - so this guard protects against any potential breaking change in WLEDClient. If for some reason the private API ceases to exist, the ping heartbeat is simply disabled. The reality is that the reconnect logic and this additional heartbeat logic really belongs in WLEDClient, and I will submit a PR there as well, but given that project has seen no updates since 2022, I'd rather implement here immediately, since it is clean and easy to do so, and worry about the upstream client library later. Nothing will break if it does get implemented there, it will simply meant that a future update here can switch over to built in reconnect behavior in the client library.

Fixes #444 